### PR TITLE
Changing from RawPath to RawQuery

### DIFF
--- a/20urls/main.go
+++ b/20urls/main.go
@@ -30,10 +30,10 @@ func main() {
 	}
 
 	partsOfUrl := &url.URL{
-		Scheme:  "https",
-		Host:    "lco.dev",
-		Path:    "/tutcss",
-		RawPath: "user=hitesh",
+		Scheme:   "https",
+		Host:     "lco.dev",
+		Path:     "/tutcss",
+		RawQuery: "user=hitesh",
 	}
 
 	anotherURL := partsOfUrl.String()


### PR DESCRIPTION
There is a typo in the URLs tutorial. RawPath is used instead of RawQuery.