### PR TITLE
correct the typo of content-type

### DIFF
--- a/24buildapi/main.go
+++ b/24buildapi/main.go
@@ -70,7 +70,7 @@ func getAllCourses(w http.ResponseWriter, r *http.Request) {
 
 func getOneCourse(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Get one course")
-	w.Header().Set("Content-Type", "applicatioan/json")
+	w.Header().Set("Content-Type", "application/json")
 
 	// grab id from request
 	params := mux.Vars(r)


### PR DESCRIPTION
There was a typo in content-type in 24buildapi directorie's main.go, fixed that.
Thanks!